### PR TITLE
Change template readme.md to use new david devDependency links

### DIFF
--- a/api/templates/_README.md
+++ b/api/templates/_README.md
@@ -3,7 +3,7 @@
 <%= description %><% if (isGithub) { %>
 
 [![Dependency Status](https://david-dm.org/<%= githubOwner %>/<%= appName %>.svg)](https://david-dm.org/<%= githubOwner %>/<%= appName %>)
-[![devDependency Status](https://david-dm.org/<%= githubOwner %>/<%= appName %>/dev-status.svg?theme=shields.io)](https://david-dm.org/<%= githubOwner %>/<%= appName %>#info=devDependencies)
+[![devDependency Status](https://david-dm.org/<%= githubOwner %>/<%= appName %>/dev-status.svg?theme=shields.io)](https://david-dm.org/<%= githubOwner %>/<%= appName %>?type=dev)
 [![Build Status](https://travis-ci.org/<%= githubOwner %>/<%= appName %>.svg?branch=master)](https://travis-ci.org/<%= githubOwner %>/<%= appName %>)<% } %>
 
 

--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -3,7 +3,7 @@
 <%= description %><% if (isGithub) { %>
 
 [![Dependency Status](https://david-dm.org/<%= githubOwner %>/<%= appName %>.svg)](https://david-dm.org/<%= githubOwner %>/<%= appName %>)
-[![devDependency Status](https://david-dm.org/<%= githubOwner %>/<%= appName %>/dev-status.svg?theme=shields.io)](https://david-dm.org/<%= githubOwner %>/<%= appName %>#info=devDependencies)
+[![devDependency Status](https://david-dm.org/<%= githubOwner %>/<%= appName %>/dev-status.svg?theme=shields.io)](https://david-dm.org/<%= githubOwner %>/<%= appName %>?type=dev)
 [![Build Status](https://travis-ci.org/<%= githubOwner %>/<%= appName %>.svg?branch=master)](https://travis-ci.org/<%= githubOwner %>/<%= appName %>)<% } %>
 
 

--- a/plugin/templates/_README.md
+++ b/plugin/templates/_README.md
@@ -3,7 +3,7 @@
 <%= description %><% if (isGithub) { %>
 
 [![Dependency Status](https://david-dm.org/<%= githubOwner %>/<%= pluginName %>.svg)](https://david-dm.org/<%= githubOwner %>/<%= pluginName %>)
-[![devDependency Status](https://david-dm.org/<%= githubOwner %>/<%= pluginName %>/dev-status.svg?theme=shields.io)](https://david-dm.org/<%= githubOwner %>/<%= pluginName %>#info=devDependencies)
+[![devDependency Status](https://david-dm.org/<%= githubOwner %>/<%= pluginName %>/dev-status.svg?theme=shields.io)](https://david-dm.org/<%= githubOwner %>/<%= pluginName %>?type=dev)
 [![Build Status](https://travis-ci.org/<%= githubOwner %>/<%= pluginName %>.svg?branch=master)](https://travis-ci.org/<%= githubOwner %>/<%= pluginName %>)<% } %>
 
 

--- a/web/templates/_README.md
+++ b/web/templates/_README.md
@@ -3,7 +3,7 @@
 <%= description %><% if (isGithub) { %>
 
 [![Dependency Status](https://david-dm.org/<%= githubOwner %>/<%= appName %>.svg)](https://david-dm.org/<%= githubOwner %>/<%= appName %>)
-[![devDependency Status](https://david-dm.org/<%= githubOwner %>/<%= appName %>/dev-status.svg?theme=shields.io)](https://david-dm.org/<%= githubOwner %>/<%= appName %>#info=devDependencies)
+[![devDependency Status](https://david-dm.org/<%= githubOwner %>/<%= appName %>/dev-status.svg?theme=shields.io)](https://david-dm.org/<%= githubOwner %>/<%= appName %>?type=dev)
 [![Build Status](https://travis-ci.org/<%= githubOwner %>/<%= appName %>.svg?branch=master)](https://travis-ci.org/<%= githubOwner %>/<%= appName %>)<% } %>
 
 


### PR DESCRIPTION
The old devDependency links were causing me problems by showing the wrong number of dev dependencies I have and their version, so I had a look at the issues from david and it seems that they changed the devDependency links.
Instead of `#info=devDependencies` they now use `?type=dev`, once I did this change in my own project david started displaying the right badge and details. 

Official David issue [here](https://github.com/alanshaw/david-www/issues/333)