### PR TITLE
Throw on error in server.start().

### DIFF
--- a/api/templates/server.js
+++ b/api/templates/server.js
@@ -9,10 +9,10 @@ Composer((err, server) => {
         throw err;
     }
 
-    server.start((err) => {
+    server.start((error) => {
 
-        if (err) {
-            throw err;
+        if (error) {
+            throw error;
         }
 
         console.log('Started the plot device on port ' + server.info.port);

--- a/api/templates/server.js
+++ b/api/templates/server.js
@@ -9,7 +9,11 @@ Composer((err, server) => {
         throw err;
     }
 
-    server.start(() => {
+    server.start((err) => {
+
+        if (err) {
+            throw err;
+        }
 
         console.log('Started the plot device on port ' + server.info.port);
     });

--- a/app/templates/server.js
+++ b/app/templates/server.js
@@ -9,10 +9,10 @@ Composer((err, server) => {
         throw err;
     }
 
-    server.start((err) => {
+    server.start((error) => {
 
-        if (err) {
-            throw err;
+        if (error) {
+            throw error;
         }
 
         console.log('Started the plot device on port ' + server.info.port);

--- a/app/templates/server.js
+++ b/app/templates/server.js
@@ -9,7 +9,7 @@ Composer((err, server) => {
         throw err;
     }
 
-    server.start(() => {
+    server.start((err) => {
 
         if (err) {
             throw err;

--- a/app/templates/server.js
+++ b/app/templates/server.js
@@ -11,6 +11,10 @@ Composer((err, server) => {
 
     server.start(() => {
 
+        if (err) {
+            throw err;
+        }
+
         console.log('Started the plot device on port ' + server.info.port);
     });
 });

--- a/web/templates/server.js
+++ b/web/templates/server.js
@@ -9,10 +9,10 @@ Composer((err, server) => {
         throw err;
     }
 
-    server.start((err) => {
+    server.start((error) => {
 
-        if (err) {
-            throw err;
+        if (error) {
+            throw error;
         }
 
         console.log('Started the plot device on port ' + server.info.port);

--- a/web/templates/server.js
+++ b/web/templates/server.js
@@ -9,7 +9,11 @@ Composer((err, server) => {
         throw err;
     }
 
-    server.start(() => {
+    server.start((err) => {
+
+        if (err) {
+            throw err;
+        }
 
         console.log('Started the plot device on port ' + server.info.port);
     });


### PR DESCRIPTION
Servers fails silently if the port is already in use. This second throw makes the error more explicit.